### PR TITLE
fix: correct stack trace handling in error handler

### DIFF
--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -10,7 +10,8 @@ export function errorHandler(
 
     const statusCode = error.statusCode || 500;
     const message = error.message || "Internal Server Error";
-    const stack = process.env.NODE_ENV === "development" ? null : error.stack;
+    // Show stack traces in non-production environments for easier debugging
+    const stack = process.env.NODE_ENV === "production" ? null : error.stack;
 
     res.status(statusCode).json({
         status: statusCode === 500 ? "error" : "fail",


### PR DESCRIPTION
## Summary
- ensure error handler only hides stack traces in production

## Testing
- `npm test` (fails: MongoDB connection error: The `uri` parameter to `openUri()` must be a string, got "undefined"...)


------
https://chatgpt.com/codex/tasks/task_e_68966d647f3483279a1830e83d27e864