### PR TITLE
refactor(swagger): load docs from yaml

### DIFF
--- a/backend/docs/health.yaml
+++ b/backend/docs/health.yaml
@@ -1,0 +1,7 @@
+paths:
+  /api/v1/health:
+    get:
+      summary: Health check endpoint
+      responses:
+        '200':
+          description: Returns the service health status

--- a/backend/docs/item.yaml
+++ b/backend/docs/item.yaml
@@ -1,0 +1,26 @@
+paths:
+  /api/v1/items:
+    get:
+      summary: Retrieve a list of items
+      responses:
+        '200':
+          description: A list of items
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Item'
+components:
+  schemas:
+    Item:
+      type: object
+      properties:
+        id:
+          type: string
+        name:
+          type: string
+        description:
+          type: string
+        price:
+          type: number

--- a/backend/src/config/swagger.ts
+++ b/backend/src/config/swagger.ts
@@ -15,17 +15,19 @@ const swaggerOptions: { definition: typeof swaggerDefinition; apis: string[] } =
   apis: [],
 };
 
-if (process.env.NODE_ENV === 'production'){
+if (process.env.NODE_ENV === 'production') {
   swaggerOptions.apis = [
-    ...swaggerOptions.apis,
-    'dist/**/*.js'
-  ]
+    'dist/routes/**/*.js',
+    'docs/**/*.yaml',
+  ];
 } else {
-  console.log("📝 Swagger Docs: Development mode detected, using TypeScript files for API documentation.");
+  console.log(
+    '📝 Swagger Docs: Development mode detected, using TypeScript files for API documentation.'
+  );
   swaggerOptions.apis = [
-    ...swaggerOptions.apis,
-    'src/**/*.ts'
-  ]
+    'src/routes/**/*.ts',
+    'docs/**/*.yaml',
+  ];
 }
 
 const swaggerSpec = swaggerJSDoc(swaggerOptions);

--- a/backend/src/middleware/healthCheck.ts
+++ b/backend/src/middleware/healthCheck.ts
@@ -1,15 +1,6 @@
 import { Request, Response } from 'express';
 import { getHealthStatus } from '../services/health.service';
 
-/**
- * @openapi
- * /api/v1/health:
- *   get:
- *     summary: Health check endpoint
- *     responses:
- *       '200':
- *         description: Returns the service health status
- */
 
 export function healthCheck(_req: Request, res: Response) {
   const status = getHealthStatus();

--- a/backend/src/models/item.model.ts
+++ b/backend/src/models/item.model.ts
@@ -1,21 +1,5 @@
 import mongoose, { Schema, Document, Model } from "mongoose";
 
-/**
- * @openapi
- * components:
- *   schemas:
- *     Item:
- *       type: object
- *       properties:
- *         id:
- *           type: string
- *         name:
- *           type: string
- *         description:
- *           type: string
- *         price:
- *           type: number
- */
 
 interface IItem extends Document {
     id: string;

--- a/backend/src/routes/item.route.ts
+++ b/backend/src/routes/item.route.ts
@@ -3,21 +3,6 @@ import { getAllItems } from "../controllers/item.controller";
 
 const router = express.Router();
 
-/**
- * @openapi
- * /api/v1/items:
- *   get:
- *     summary: Retrieve a list of items
- *     responses:
- *       '200':
- *         description: A list of items
- *         content:
- *           application/json:
- *             schema:
- *               type: array
- *               items:
- *                 $ref: '#/components/schemas/Item'
- */
 
 router.get("/", getAllItems);
 


### PR DESCRIPTION
## Summary
- move OpenAPI definitions into standalone YAML docs
- load docs from `docs/**/*.yaml` in swagger config
- strip `@openapi` blocks from source files

## Testing
- `npm test` *(fails: MongoDB connection error when starting dev server for e2e tests)*
- `npm run build` *(fails: TS6059: File not under rootDir)*
- `npm run dev` *(fails: MongoDB connection error)*

------
https://chatgpt.com/codex/tasks/task_e_6897bda66aac8327ab62d9e99d96c72a