### PR TITLE
refactor: add product service

### DIFF
--- a/backend/src/config/mongodb.ts
+++ b/backend/src/config/mongodb.ts
@@ -1,12 +1,6 @@
 import mongoose from "mongoose";
 
 export const connectDB = async () => {
-  // Skip actual MongoDB connection during Cypress tests
-  if (process.env.MOCK_DB === 'true') {
-    console.log('🧪 Using mocked database connection');
-    return;
-  }
-
   try {
     await mongoose.connect(process.env.DB_URI as string, {
       //   useNewUrlParser: true,

--- a/backend/src/controllers/product.controller.ts
+++ b/backend/src/controllers/product.controller.ts
@@ -1,28 +1,14 @@
-import { NextFunction, RequestHandler, Request, Response } from "express";
-import { Product } from "../models/product.model";
-import { ProductType } from '../../src/types/product.type';
-
-// In-memory mock data used when running with a mocked database
-const mockProducts: ProductType[] = [
-  { _id: '1', name: 'Alpha', description: 'Test A', msrp: 15, price: 10 },
-  { _id: '2', name: 'Bravo', description: 'Test B', msrp: 25, price: 20 },
-  { _id: '3', name: 'Charlie', description: 'Test C', msrp: 35, price: 30 },
-];
-
+import { NextFunction, Request, RequestHandler, Response } from "express";
+import * as ProductService from "../services/product.service";
+import { ProductType } from "../types/product.type";
 
 export const getAllProducts: RequestHandler<{}, ProductType[]> = async (
   _req: Request,
   res: Response,
   next?: NextFunction,
 ) => {
-  // When MOCK_DB is enabled (Cypress), return mock data instead of querying MongoDB
-  if (process.env.MOCK_DB === 'true') {
-    res.status(200).json(mockProducts);
-    return;
-  }
-
   try {
-    const products = await Product.find().lean<ProductType[]>();
+    const products = await ProductService.findAll();
     res.status(200).json(products);
   } catch (error) {
     if (next) {
@@ -37,21 +23,9 @@ export const createProduct: RequestHandler<{}, ProductType> = async (
   res: Response,
   next?: NextFunction,
 ) => {
-  // When MOCK_DB is enabled (Cypress), push to the mock array instead of using MongoDB
-  if (process.env.MOCK_DB === 'true') {
-    const newProduct: ProductType = {
-      _id: String(mockProducts.length + 1),
-      ...req.body,
-    };
-    mockProducts.push(newProduct);
-    res.status(201).json(newProduct);
-    return;
-  }
-
   try {
-    const newProduct = new Product(req.body);
-    const savedProduct = await newProduct.save();
-    res.status(201).json(savedProduct.toObject());
+    const savedProduct = await ProductService.create(req.body);
+    res.status(201).json(savedProduct);
   } catch (error) {
     if (next) {
       next(error);

--- a/backend/src/services/product.service.ts
+++ b/backend/src/services/product.service.ts
@@ -1,0 +1,13 @@
+import { Product } from "../models/product.model";
+import { ProductType } from "../types/product.type";
+
+export async function findAll(): Promise<ProductType[]> {
+  const products = await Product.find().lean<ProductType[]>();
+  return products;
+}
+
+export async function create(data: Omit<ProductType, '_id'>): Promise<ProductType> {
+  const newProduct = new Product(data);
+  const savedProduct = await newProduct.save();
+  return savedProduct.toObject();
+}

--- a/backend/tests/api/product.spec.ts
+++ b/backend/tests/api/product.spec.ts
@@ -1,38 +1,36 @@
 /** @type {import('ts-jest').JestConfigWithTsJest} */
 
-const productController = require('../../src/controllers/product.controller');
-import { getAllProducts } from '../../src/controllers/product.controller';
+import * as productController from '../../src/controllers/product.controller';
+import * as ProductService from '../../src/services/product.service';
 import { jest } from "@jest/globals";
-import { Product } from '../../src/models/product.model';
 import { ProductType } from '../../src/types/product.type';
 
-// Write a test for the getAllProducts function
 describe('Product Controller', () => {
-it('should fetch all products', async () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should fetch all products', async () => {
     const mockProducts: ProductType[] = [
-        { _id: '1', name: 'Product 1', description: 'Description 1', msrp: 110, price: 100 },
-        { _id: '2', name: 'Product 2', description: 'Description 2', msrp: 210, price: 200 },
+      { _id: '1', name: 'Product 1', description: 'Description 1', msrp: 110, price: 100 },
+      { _id: '2', name: 'Product 2', description: 'Description 2', msrp: 210, price: 200 },
     ];
 
-    jest.spyOn(Product, 'find').mockReturnValue({
-        lean: () => Promise.resolve(mockProducts),
-    } as unknown as any);
+    jest.spyOn(ProductService, 'findAll').mockResolvedValue(mockProducts as any);
 
     const req: any = {};
     const res: any = {
-        status: jest.fn().mockReturnThis(),
-        json: jest.fn(),
+      status: jest.fn().mockReturnThis(),
+      json: jest.fn(),
     };
     const next = jest.fn();
 
-    await getAllProducts(req, res, next);
+    await productController.getAllProducts(req, res, next);
 
     expect(res.status).toHaveBeenCalledWith(200);
     expect(res.json).toHaveBeenCalledWith(mockProducts);
-
   });
 
-  // Write a test for a 500 error in getAllProducts
   it('should handle errors in getAllProducts', async () => {
     const req: any = {};
     const res: any = {
@@ -41,18 +39,14 @@ it('should fetch all products', async () => {
     };
     const next = jest.fn();
 
-    // Simulate an error by throwing an exception
-    jest.spyOn(Product, 'find').mockImplementation(() => {
-      throw new Error('Database error');
-    });
+    jest.spyOn(ProductService, 'findAll').mockRejectedValue(new Error('Database error'));
 
-    await getAllProducts(req, res, next);
+    await productController.getAllProducts(req, res, next);
 
     expect(res.status).toHaveBeenCalledWith(500);
     expect(res.json).toHaveBeenCalledWith({ error: expect.stringContaining('Error fetching products') });
   });
 
-  // Write a test for the createProduct function
   it('should create a new product', async () => {
     const newProductData: Omit<ProductType, '_id'> = {
       name: 'New Product',
@@ -62,9 +56,7 @@ it('should fetch all products', async () => {
     };
     const savedProduct: ProductType = { _id: '3', ...newProductData };
 
-    jest.spyOn(Product.prototype, 'save').mockResolvedValue({
-      toObject: () => savedProduct,
-    } as unknown as any);
+    jest.spyOn(ProductService, 'create').mockResolvedValue(savedProduct as any);
 
     const req: any = { body: newProductData };
     const res: any = {
@@ -79,7 +71,6 @@ it('should fetch all products', async () => {
     expect(res.json).toHaveBeenCalledWith(savedProduct);
   });
 
-  // Write a test for a 500 error in createProduct
   it('should handle errors in createProduct', async () => {
     const req: any = { body: {} };
     const res: any = {
@@ -88,10 +79,7 @@ it('should fetch all products', async () => {
     };
     const next = jest.fn();
 
-    // Simulate an error by throwing an exception
-    jest.spyOn(Product.prototype, 'save').mockImplementation(() => {
-      throw new Error('Database error');
-    });
+    jest.spyOn(ProductService, 'create').mockRejectedValue(new Error('Database error'));
 
     await productController.createProduct(req, res, next);
 


### PR DESCRIPTION
## Summary
- add ProductService with findAll and create methods
- refactor product controller to use ProductService instead of mock data
- always connect to MongoDB via URI

## Testing
- `npm run test:unit`
- `npm test` *(fails: MongoDB connection error)*

------
https://chatgpt.com/codex/tasks/task_e_689a122b47bc8327af46477f29bdaf47