### PR TITLE
feat: use in-memory database for test runs

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,7 @@
     "build": "tsc",
     "test": "npm run test:unit && npm run test:e2e",
     "test:unit": "npx jest --config jest.config.ts",
-    "test:e2e": "NODE_ENV=test MOCK_DB=true start-server-and-test 'npm run dev' http://localhost:5001/api/v1/health 'cypress run --headless'",
+    "test:e2e": "NODE_ENV=test start-server-and-test 'npm run dev' http://localhost:5001/api/v1/health 'cypress run --headless'",
     "cypress:open": "cypress open"
 
   },

--- a/backend/src/config/mongodb.ts
+++ b/backend/src/config/mongodb.ts
@@ -1,14 +1,31 @@
-import mongoose from "mongoose";
+import mongoose from 'mongoose';
+import { startMockDB, stopMockDB } from './test-db';
 
 export const connectDB = async () => {
   try {
+    if (process.env.NODE_ENV === 'test') {
+      startMockDB();
+      console.log('✅ Using in-memory mock database');
+      return;
+    }
     await mongoose.connect(process.env.DB_URI as string, {
       //   useNewUrlParser: true,
       //   useUnifiedTopology: true,
     });
-    console.log("✅ Connected to MongoDB");
+    console.log('✅ Connected to MongoDB');
   } catch (error) {
-    console.error("❌ MongoDB connection error:", error);
+    console.error('❌ MongoDB connection error:', error);
     process.exit(1);
   }
 };
+
+export const disconnectDB = async () => {
+  if (process.env.NODE_ENV === 'test') {
+    stopMockDB();
+  } else {
+    await mongoose.connection.close();
+  }
+};
+
+process.on('SIGINT', disconnectDB);
+process.on('SIGTERM', disconnectDB);

--- a/backend/src/config/test-db.ts
+++ b/backend/src/config/test-db.ts
@@ -1,0 +1,42 @@
+import { Product } from '../models/product.model';
+import { ProductType } from '../types/product.type';
+
+// In-memory store for products used during tests
+let products: ProductType[] = [];
+
+// Preserve original model methods so they can be restored
+const originalFind = Product.find;
+const originalSave = Product.prototype.save;
+
+export const startMockDB = () => {
+  // Seed with sample products
+  products = [
+    { _id: '1', name: 'Alpha', description: 'Test A', price: 10, msrp: 15 },
+    { _id: '2', name: 'Bravo', description: 'Test B', price: 20, msrp: 25 },
+    { _id: '3', name: 'Charlie', description: 'Test C', price: 30, msrp: 35 },
+  ];
+
+  // Mock Product.find to return the in-memory products
+  (Product.find as any) = () => ({
+    lean: async () => products,
+  });
+
+  // Mock save to push into the in-memory array
+  (Product.prototype.save as any) = function (this: any) {
+    const newProduct: ProductType = {
+      _id: (products.length + 1).toString(),
+      ...this.toObject(),
+    };
+    products.push(newProduct);
+    return { toObject: () => newProduct } as any;
+  };
+};
+
+export const stopMockDB = () => {
+  // Restore original methods
+  Product.find = originalFind;
+  Product.prototype.save = originalSave;
+  products = [];
+};
+
+export default { startMockDB, stopMockDB };


### PR DESCRIPTION
## Summary
- mock Product model with in-memory store when `NODE_ENV=test`
- ensure Mongo connection helper toggles between real and mocked DB
- streamline Cypress test script for test environment

## Testing
- `npm test` *(fails: Missing dependency Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_689a14b655c08327bf2fdf428413cec8