### PR TITLE
Updates for Release Branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,17 +96,21 @@ const { data } = await client.GET('/api/v1/products');
 
 **Production URL:** https://spoker-app.rainierserver.com
 
+**Requirement:** Deployments only allowed from `release/*` branches.
+
 ### Deploy via CI/CD (recommended)
 ```bash
-git tag v1.0.0
-git push origin v1.0.0
+git checkout -b release/v1.0    # Create release branch
+git tag v1.0.0                   # Tag on release branch
+git push origin release/v1.0 v1.0.0
 ```
-Triggers GitHub Actions → tests → self-hosted runner deploys to Rainier.
+Triggers GitHub Actions → tests → validates release branch → deploys to Rainier.
 
 ### Manual Deploy
 ```bash
-./scripts/deploy.sh          # Interactive with confirmation
-./scripts/deploy.sh --yes    # Non-interactive (CI/CD mode)
+git checkout release/v1.0        # Must be on a release branch
+./scripts/deploy.sh              # Interactive with confirmation
+./scripts/deploy.sh --yes        # Non-interactive (CI/CD mode)
 ```
 
 ### Key Files

--- a/backend/nodemon.json
+++ b/backend/nodemon.json
@@ -2,6 +2,5 @@
   "watch": ["src"],
   "ext": "ts,json",
   "ignore": ["dist"],
-  "exec": "ts-node src/server.ts",
-  "legacyWatch": true
+  "exec": "ts-node src/server.ts"
 }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,3 +1,5 @@
+version: '3.9'
+
 services:
   nginx:
     image: spokerv2-nginx-dev
@@ -19,20 +21,11 @@ services:
       - ./frontend:/app
       - /app/node_modules
     expose:
-      - "4200"
+      - "80"
     ports:
       - "4200:4200"
     environment:
       - NODE_ENV=development
-      - CHOKIDAR_USEPOLLING=true
-      - WATCHPACK_POLLING=true
-    develop:
-      watch:
-        - action: sync
-          path: ./frontend/src
-          target: /app/src
-        - action: rebuild
-          path: ./frontend/package.json
 
   backend:
     image: spokerv2-backend-dev
@@ -50,11 +43,3 @@ services:
       - ./backend/.env
     environment:
       - NODE_ENV=development
-      - CHOKIDAR_USEPOLLING=true
-    develop:
-      watch:
-        - action: sync
-          path: ./backend/src
-          target: /app/src
-        - action: rebuild
-          path: ./backend/package.json

--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -67,8 +67,7 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "proxyConfig": "proxy.conf.json",
-            "poll": 1000
+            "proxyConfig": "proxy.conf.json"
           },
           "configurations": {
             "production": {

--- a/frontend/src/index.html
+++ b/frontend/src/index.html
@@ -14,6 +14,9 @@
   <app-root></app-root>
 </body>
 <hr>
-<div class="site-footer"> Self-hosted on <a href="https://rainierserver.com/">rainierserver.com</a></div>
-
+    <footer>
+      <div>© 2026 <a href="https://forrestmorrisey.com/">Forrest Morrisey</a> — Self-Hosted on <a href="https://rainierserver.com/">Rainier Server</a> 🏔</div>
+      <div>Project Source Code: <a href="https://github.com/fmorrisey/Spokerv2">Spokerv2 on Github</a></div>
+      <div><small>Last updated: <script>document.write(new Date(document.lastModified).toLocaleString())</script></small></div>
+    </footer>
 </html>

--- a/frontend/src/styles.scss
+++ b/frontend/src/styles.scss
@@ -9,10 +9,11 @@ html {
     color: white;
 }
 
-.site-footer {
+footer {
     padding: 1rem;
     font-size: 1.6rem;
     display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
     margin:auto;

--- a/nginx/default.dev.conf
+++ b/nginx/default.dev.conf
@@ -3,7 +3,7 @@ map $http_upgrade $connection_upgrade {
     ''      close;
 }
 
-upstream spoker_frontend { server frontend:4200; }
+upstream spoker_frontend { server frontend:80; }
 upstream spoker_backend  { server backend:5001; }
 
 server {
@@ -34,14 +34,10 @@ server {
 
     location / {
         proxy_pass http://spoker_frontend;
-        proxy_http_version 1.1;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection $connection_upgrade;
-        proxy_cache_bypass $http_upgrade;
         # Disable caching for development
         expires -1;
         add_header Cache-Control "no-cache, no-store, must-revalidate";


### PR DESCRIPTION
This pull request strengthens deployment safety by enforcing that all deployments—whether via CI/CD or manual scripts—can only occur from `release/*` branches. Documentation and workflow files have been updated to clarify and enforce this requirement, and the frontend footer has been improved for better project attribution and information.

Deployment branch enforcement:

* [`.github/workflows/deploy.yml`](diffhunk://#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3R79-R89): Added a check to ensure tags are only deployed if they are on a `release/*` branch, aborting otherwise.
* [`scripts/deploy.sh`](diffhunk://#diff-37cb4e5e5a1884f59247915193e6246be6df0129ae8e233b8a78c0c91d47dc04R33-R63): Introduced a `validate_release_branch` function that prevents manual deployments unless on a `release/*` branch or a tag on such a branch.

Documentation updates:

* [`deploy/DEPLOYMENT.md`](diffhunk://#diff-8bae48d80e3fc117174eafbf0dbd43b1022f0700df1678374739e81e318768d1L37-R60): Clarified that deployments (CI/CD and manual) must be from `release/*` branches, added requirements for tag format and branch validation, and updated pipeline flow steps. [[1]](diffhunk://#diff-8bae48d80e3fc117174eafbf0dbd43b1022f0700df1678374739e81e318768d1L37-R60) [[2]](diffhunk://#diff-8bae48d80e3fc117174eafbf0dbd43b1022f0700df1678374739e81e318768d1L102-R123)
* [`CLAUDE.md`](diffhunk://#diff-6ebdb617a8104a7756d0cf36578ab01103dc9f07e4dc6feb751296b9c402faf7R99-R111): Updated instructions to require tagging and pushing from a `release/*` branch, and described the new validation step in the pipeline.

Frontend footer improvements:

* `frontend/src/index.html`, `frontend/src/styles.scss`: Replaced the old site footer with a more informative footer, including project attribution, source code link, and last updated timestamp. [[1]](diffhunk://#diff-1871fc7d48e49a8b5e54149bb3d277640eb0818d14aed00b20ebc52a3f81e3dbL17-R21) [[2]](diffhunk://#diff-fd379086747415867d7f061a264f1830dac9c60d91e906d1ad7f5cacf8d684dbL12-R16)