### PR TITLE
Product Seeded for Mongo DB

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,8 @@
     "start": "node dist/server.js",
     "build": "tsc",
     "test": "NODE_ENV=test npm run test:unit",
-    "test:unit": "npx jest --config jest.config.ts --coverage"
+    "test:unit": "npx jest --config jest.config.ts --coverage",
+    "seed": "npx ts-node src/scripts/seed.ts"
   },
   "keywords": [],
   "author": "",

--- a/backend/src/models/product.model.ts
+++ b/backend/src/models/product.model.ts
@@ -28,15 +28,48 @@ const productSchema = new Schema<IProduct>({
 });
 
 productSchema.statics.seed = async function () {
-    const sampleProducts : ProductSchema[] = [
-        { _id: '', name: 'Alpha', description: 'Test A', price: 10, msrp: 15 },
-        { _id: '', name: 'Bravo', description: 'Test B', price: 20, msrp: 25 },
-        { _id: '', name: 'Charlie', description: 'Test C', price: 30, msrp: 35 },
+    const sampleProducts: Omit<ProductSchema, '_id'>[] = [
+        // Electronics
+        { name: 'Wireless Noise-Cancelling Headphones', description: 'Premium over-ear headphones with active noise cancellation, 30-hour battery life, and hi-res audio support. Foldable design with carrying case included.', msrp: 349.99, price: 279.99 },
+        { name: '4K Ultra HD Monitor 27"', description: 'IPS panel with 99% sRGB color accuracy, USB-C power delivery, and adjustable stand. Perfect for creative professionals and developers.', msrp: 499.99, price: 449.99 },
+        { name: 'Mechanical Keyboard RGB', description: 'Hot-swappable switches, per-key RGB lighting, aluminum frame, and programmable macros. Includes wrist rest and keycap puller.', msrp: 159.99, price: 129.99 },
+        { name: 'Portable Bluetooth Speaker', description: 'Waterproof IPX7 speaker with 360-degree sound, 20-hour playtime, and built-in microphone for calls. Pairs with up to 3 devices.', msrp: 129.99, price: 89.99 },
+        { name: 'USB-C Docking Station', description: 'Triple display support, 100W power delivery, 10Gbps data transfer. Includes HDMI, DisplayPort, Ethernet, and SD card reader.', msrp: 199.99, price: 179.99 },
+
+        // Clothing
+        { name: 'Merino Wool Quarter-Zip', description: 'Lightweight merino wool pullover with moisture-wicking properties. Machine washable, odor-resistant, and perfect for layering in any season.', msrp: 128.00, price: 98.00 },
+        { name: 'Stretch Chino Pants', description: 'Tailored fit chinos with 2% elastane for all-day comfort. Wrinkle-resistant fabric with reinforced seams. Available in 6 colors.', msrp: 89.00, price: 89.00 },
+        { name: 'Trail Running Shoes', description: 'Aggressive tread pattern with Vibram outsole, waterproof membrane, and responsive cushioning. Built for technical terrain.', msrp: 165.00, price: 132.00 },
+        { name: 'Insulated Rain Jacket', description: 'Three-layer waterproof shell with sealed seams, adjustable hood, and pit zips. Packs into its own pocket for travel.', msrp: 225.00, price: 189.00 },
+
+        // Home Goods
+        { name: 'Cast Iron Dutch Oven 6Qt', description: 'Enameled cast iron with self-basting lid. Even heat distribution for braising, baking, and slow cooking. Oven safe to 500°F.', msrp: 89.99, price: 69.99 },
+        { name: 'Pour-Over Coffee Maker Set', description: 'Borosilicate glass carafe with stainless steel reusable filter. Includes gooseneck kettle, scale, and brewing guide.', msrp: 74.99, price: 59.99 },
+        { name: 'Smart LED Desk Lamp', description: 'Adjustable color temperature from 2700K to 6500K with memory function. USB charging port, auto-dimming sensor, and 50,000-hour lifespan.', msrp: 79.99, price: 64.99 },
+        { name: 'Bamboo Cutting Board Set', description: 'Set of 3 organic bamboo boards with juice grooves and non-slip edges. Naturally antimicrobial and knife-friendly surface.', msrp: 49.99, price: 39.99 },
+
+        // Tech Accessories
+        { name: 'Laptop Backpack 15.6"', description: 'Water-resistant fabric with padded laptop compartment, hidden anti-theft pocket, and USB charging port. TSA-friendly design.', msrp: 79.99, price: 59.99 },
+        { name: 'Wireless Charging Pad Duo', description: 'Charges two devices simultaneously at 15W each. Compatible with all Qi-enabled devices. Includes USB-C cable and wall adapter.', msrp: 49.99, price: 34.99 },
+        { name: '1TB Portable SSD', description: 'Read speeds up to 1050 MB/s in a shock-resistant aluminum enclosure. USB-C with backward-compatible USB-A cable included.', msrp: 109.99, price: 89.99 },
+        { name: 'Webcam 4K AutoFocus', description: 'Sony STARVIS sensor with HDR, dual noise-cancelling microphones, and automatic low-light correction. Privacy shutter included.', msrp: 149.99, price: 119.99 },
+
+        // Fitness
+        { name: 'Adjustable Dumbbell Set 5-50lb', description: 'Quick-change weight selector replaces 15 pairs of dumbbells. Durable steel construction with textured grip. Includes storage tray.', msrp: 399.99, price: 349.99 },
+        { name: 'Yoga Mat Premium 6mm', description: 'Non-slip natural rubber with alignment markings. Closed-cell surface resists moisture and bacteria. Includes carrying strap.', msrp: 69.99, price: 54.99 },
+
+        // Pets
+        { name: 'Butch the Cat', description: 'Distinguished tuxedo gentleman with an industrial-grade purr motor and impeccable manners. The sweetest boy you will ever meet. Not actually for sale — he is priceless.', msrp: 999999.99, price: 999999.99 },
     ];
 
-    await this.deleteMany({});
+    const existing = await this.countDocuments();
+    if (existing > 0) {
+        console.log(`⏭️  Skipping seed — ${existing} products already exist. Use --force to replace.`);
+        return;
+    }
+
     await this.insertMany(sampleProducts);
-    console.log('✅ Product seed complete');
+    console.log(`✅ Seeded ${sampleProducts.length} products`);
 };
 
 export const Product = mongoose.model<IProduct, ProductModel>('Product', productSchema);

--- a/backend/src/scripts/seed.ts
+++ b/backend/src/scripts/seed.ts
@@ -1,0 +1,40 @@
+import path from 'path';
+import dotenv from 'dotenv';
+import mongoose from 'mongoose';
+import { Product } from '../models/product.model';
+
+// Parse args
+const args = process.argv.slice(2);
+const envArg = args.find(a => a.startsWith('--env='));
+const envFile = envArg ? envArg.split('=')[1] : '.env';
+const envPath = path.resolve(__dirname, '../../', envFile);
+const force = args.includes('--force');
+
+dotenv.config({ path: envPath });
+
+if (!process.env.DB_URI) {
+    console.error(`❌ DB_URI not found. Checked: ${envPath}`);
+    console.error('   Try: npm run seed -- --env=.env.prod');
+    process.exit(1);
+}
+
+async function main() {
+    console.log(`🔌 Connecting to database...`);
+    await mongoose.connect(process.env.DB_URI as string);
+    console.log('✅ Connected');
+
+    if (force) {
+        const deleted = await Product.deleteMany({});
+        console.log(`🗑️  Cleared ${deleted.deletedCount} existing products`);
+    }
+
+    await Product.seed();
+
+    await mongoose.connection.close();
+    console.log('🔌 Disconnected');
+}
+
+main().catch(err => {
+    console.error('❌ Seed failed:', err.message);
+    process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
         "test:backend": "npm run test --prefix=backend",
         "test:frontend": "npm run test --prefix=frontend",
         "swagger:gen": "node tools/scripts/generate-types.js",
+        "seed": "node tools/scripts/seed.js",
         "deploy": "./tools/scripts/deploy.sh"
     },
     "devDependencies": {

--- a/tools/scripts/seed.js
+++ b/tools/scripts/seed.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+
+/**
+ * Seed script — populates the database with demo product data.
+ *
+ * Usage:
+ *   npm run seed                     # Seed using backend/.env (skips if data exists)
+ *   npm run seed -- --force          # Drop existing products and re-seed
+ *   npm run seed -- --env=.env.prod  # Use a specific env file
+ */
+
+const { execSync } = require('child_process');
+const path = require('path');
+
+const backendDir = path.resolve(__dirname, '../../backend');
+
+// Forward CLI args
+const args = process.argv.slice(2).join(' ');
+
+try {
+    execSync(`npx ts-node src/scripts/seed.ts ${args}`, {
+        cwd: backendDir,
+        stdio: 'inherit',
+    });
+} catch (err) {
+    process.exit(1);
+}


### PR DESCRIPTION
This pull request introduces a robust database seeding workflow for demo product data, including a new seed script, updates to the backend product seeding logic, and integration into project-level and backend-level npm scripts. The changes make it easier to populate the database with realistic sample products, support environment configuration, and provide options to force reseeding.

**Database Seeding Workflow**

* Added a new script `tools/scripts/seed.js` to enable project-level seeding, forwarding CLI arguments and environment selection to the backend seed logic.
* Created `backend/src/scripts/seed.ts`, which connects to the database, supports environment file selection and force reseeding, and invokes the product seeding logic.

**Product Seeding Logic Improvements**

* Enhanced the `Product.seed` static method in `backend/src/models/product.model.ts` to seed a diverse set of realistic products across multiple categories, skip seeding if data exists (unless forced), and improve logging.

**NPM Script Integration**

* Added a `seed` script to the root `package.json` to run the new seeding workflow.
* Added a `seed` script to `backend/package.json` for backend-specific seeding.