### PR TITLE
Deployment changes for DEMO_MODE

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -100,6 +100,26 @@ jobs:
           chmod +x tools/scripts/check-version.sh
           ./tools/scripts/check-version.sh
 
+      - name: ⚠️ Demo Mode Warning
+        run: |
+          if grep -qE '^DEMO_MODE=true' ~/code/spokerv2/deploy/.env.prod; then
+            echo "::warning title=DEMO_MODE ENABLED::DEMO_MODE=true is set in deploy/.env.prod — the production app is running in demo mode!"
+            echo ""
+            echo "  ╔══════════════════════════════════════════════════════════╗"
+            echo "  ║                                                          ║"
+            echo "  ║   ⚠️   WARNING: DEMO_MODE=true IN PRODUCTION ENV   ⚠️    ║"
+            echo "  ║                                                          ║"
+            echo "  ║   The app will run in demo mode. Real auth is bypassed   ║"
+            echo "  ║   and all product edits are session-scoped only.         ║"
+            echo "  ║                                                          ║"
+            echo "  ║   Set DEMO_MODE=false in deploy/.env.prod to disable.    ║"
+            echo "  ║                                                          ║"
+            echo "  ╚══════════════════════════════════════════════════════════╝"
+            echo ""
+          else
+            echo "✅ DEMO_MODE is not enabled"
+          fi
+
       - name: 🚀 Run Deploy Script
         run: |
           cd ~/code/spokerv2
@@ -107,7 +127,7 @@ jobs:
           ./tools/scripts/deploy.sh --yes
 
       - name: ⏳ Wait for Services
-        run: sleep 10
+        run: sleep 20
 
       - name: 🏥 Health Check
         run: |
@@ -133,13 +153,22 @@ jobs:
           fi
           echo "✅ Backend is running"
 
-          # API health check
-          if curl -sf http://localhost:8080/api/v1/health -H "Host: spoker-app.rainierserver.com" > /dev/null; then
-            echo "✅ API health check passed"
-          else
-            echo "❌ API health check failed"
-            exit 1
-          fi
+          # API health check with retries
+          MAX_RETRIES=6
+          RETRY_DELAY=10
+          for i in $(seq 1 $MAX_RETRIES); do
+            if curl -sf http://localhost:8080/api/v1/health -H "Host: spoker-app.rainierserver.com" > /dev/null; then
+              echo "✅ API health check passed (attempt $i)"
+              break
+            fi
+            if [ "$i" -eq "$MAX_RETRIES" ]; then
+              echo "❌ API health check failed after $MAX_RETRIES attempts"
+              docker logs spoker-backend --tail 50
+              exit 1
+            fi
+            echo "⏳ API not ready yet, retrying in ${RETRY_DELAY}s... (attempt $i/$MAX_RETRIES)"
+            sleep $RETRY_DELAY
+          done
 
       - name: 📢 Deployment Summary
         if: success()

--- a/tools/scripts/deploy.sh
+++ b/tools/scripts/deploy.sh
@@ -79,6 +79,29 @@ if [ ! -f "$ENV_FILE" ]; then
     exit 1
 fi
 
+# Warn loudly if DEMO_MODE is enabled in the env file
+if grep -qE '^DEMO_MODE=true' "$ENV_FILE"; then
+    echo -e "${YELLOW}"
+    echo "  ╔══════════════════════════════════════════════════════════╗"
+    echo "  ║                                                          ║"
+    echo "  ║   ⚠️   WARNING: DEMO_MODE=true IN PRODUCTION ENV   ⚠️    ║"
+    echo "  ║                                                          ║"
+    echo "  ║   The app will run in demo mode. Real auth is bypassed   ║"
+    echo "  ║   and all product edits are session-scoped only.         ║"
+    echo "  ║                                                          ║"
+    echo "  ║   Set DEMO_MODE=false in deploy/.env.prod to disable.    ║"
+    echo "  ║                                                          ║"
+    echo "  ╚══════════════════════════════════════════════════════════╝"
+    echo -e "${NC}"
+    if [ "$YES" != "true" ]; then
+        read -r -p "  Deploy with DEMO_MODE=true? [y/N] " confirm
+        if [[ ! "$confirm" =~ ^[Yy]$ ]]; then
+            echo "Aborted."
+            exit 1
+        fi
+    fi
+fi
+
 # Validate we're on a release/* branch or a tag on a release branch
 validate_release_branch() {
     local current_branch=$(git branch --show-current)


### PR DESCRIPTION
This pull request enhances deployment safety and reliability by adding explicit warnings and checks related to the `DEMO_MODE` environment variable, and by making the deployment workflow more robust. The main improvements include prominently warning when demo mode is enabled in production, requiring explicit confirmation before proceeding in such cases, and making the health check process more resilient.

**Deployment safety improvements:**

* Added a clear warning step to the GitHub Actions deploy workflow (`.github/workflows/deploy.yml`) to notify if `DEMO_MODE=true` is set in `deploy/.env.prod`, alerting users that the production app is running in demo mode.
* Updated the deploy script (`tools/scripts/deploy.sh`) to print a prominent warning and require user confirmation (unless running with `--yes`) before deploying if `DEMO_MODE=true` is detected in the environment file.

**Deployment workflow reliability:**

* Increased the wait time for services to start after deployment from 10 to 20 seconds in the GitHub Actions workflow to reduce the risk of premature health checks.
* Improved the API health check in the deploy workflow to include retries (up to 6 attempts with a delay), and to show recent backend logs if the health check ultimately fails, making troubleshooting easier.