### PR TITLE
swagger updates to make easy work of open api auths

### DIFF
--- a/backend/docs/product.yaml
+++ b/backend/docs/product.yaml
@@ -13,6 +13,8 @@ paths:
                   $ref: '#/components/schemas/Product'
     post:
       summary: Create a new product
+      security:
+        - bearerAuth: []
       requestBody:
         required: true
         content:
@@ -46,6 +48,8 @@ paths:
           description: Product not found
     put:
       summary: Update an existing product
+      security:
+        - bearerAuth: []
       parameters:
         - in: path
           name: id
@@ -69,6 +73,8 @@ paths:
           description: Product not found
     delete:
       summary: Delete an product by ID
+      security:
+        - bearerAuth: []
       parameters:
         - in: path
           name: id

--- a/backend/src/config/swagger.ts
+++ b/backend/src/config/swagger.ts
@@ -8,6 +8,15 @@ const swaggerDefinition = {
     title: 'Spoker v2 API',
     version: '1.0.0',
   },
+  components: {
+    securitySchemes: {
+      bearerAuth: {
+        type: 'http',
+        scheme: 'bearer',
+        bearerFormat: 'JWT',
+      },
+    },
+  },
 };
 
 const swaggerOptions: { definition: typeof swaggerDefinition; apis: string[] } = {


### PR DESCRIPTION
This pull request introduces security requirements for the product API endpoints and adds the bearer authentication scheme to the Swagger documentation. The main focus is to ensure that the create, update, and delete product operations require authentication, and the OpenAPI specification is updated accordingly.

Security enhancements for product endpoints:

* Added `bearerAuth` security requirement to the `POST`, `PUT`, and `DELETE` endpoints for products in `backend/docs/product.yaml`, ensuring that these operations require authentication. [[1]](diffhunk://#diff-12ba298bb848da1ae71ce419f814513ef6d820b8c109a3f24aea8b33fac7a114R16-R17) [[2]](diffhunk://#diff-12ba298bb848da1ae71ce419f814513ef6d820b8c109a3f24aea8b33fac7a114R51-R52) [[3]](diffhunk://#diff-12ba298bb848da1ae71ce419f814513ef6d820b8c109a3f24aea8b33fac7a114R76-R77)

OpenAPI/Swagger documentation updates:

* Defined the `bearerAuth` security scheme under `components.securitySchemes` in `backend/src/config/swagger.ts`, specifying the use of JWT bearer tokens for authentication.