### PR TITLE
Clean up loose ends: error service, RBAC, backend README

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -45,3 +45,17 @@ JWT_REFRESH_EXPIRATION=7d
 # Set to true to run the app in demo mode (session-scoped edits, no real auth)
 # WARNING: Do not leave this enabled in a real production environment
 DEMO_MODE=true
+
+# =============================================================================
+# ROLES / RBAC
+# =============================================================================
+# Comma-separated list of emails granted the `owner` role on register/login.
+# Owners can create/update/delete products; everyone else is a `customer`.
+# The allowlist only promotes to owner — it never demotes.
+OWNER_EMAILS=
+
+# Demo owner account created by `npm run seed`. Change the password before
+# using in any shared environment.
+SEED_OWNER_EMAIL=owner@spoker.dev
+SEED_OWNER_PASSWORD=ownerpassword
+SEED_OWNER_NAME=Demo Owner

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,125 @@
+# Spokerv2 Backend
+
+[![Backend CI](https://github.com/fmorrisey/Spokerv2/actions/workflows/backend.yml/badge.svg)](https://github.com/fmorrisey/Spokerv2/actions/workflows/backend.yml)
+
+Express.js + TypeScript API for Spoker v2. MongoDB (Mongoose) for persistence, OpenAPI 3.0 as the source of truth for types.
+
+## Setup
+
+```bash
+npm install
+```
+
+Copy the example environment file and fill in your values:
+
+```bash
+cp .env.example .env
+```
+
+Generate two independent JWT secrets:
+
+```bash
+openssl rand -base64 32   # run twice — one for JWT_SECRET, one for JWT_REFRESH_SECRET
+```
+
+## Development
+
+```bash
+npm run dev
+```
+
+Runs the server via nodemon with hot reload.
+
+- API: `http://localhost:5001`
+- Swagger UI (dev only): `http://localhost:5001/api-docs/`
+
+## Build
+
+```bash
+npm run build     # tsc → dist/
+npm start         # run the compiled server (node dist/server.js)
+```
+
+## Testing
+
+Jest with coverage:
+
+```bash
+npm test                              # all tests with coverage
+npx jest tests/api/product.spec.ts    # a single file
+```
+
+## Seeding
+
+Seeds sample products and a demo owner account:
+
+```bash
+npm run seed                    # seed against .env (skips if data already exists)
+npm run seed -- --force         # clear existing products first, then seed
+npm run seed -- --env=.env.prod # use a different env file
+```
+
+The demo owner is created from `SEED_OWNER_EMAIL` / `SEED_OWNER_PASSWORD` (defaults
+`owner@spoker.dev` / `ownerpassword`). Change the password before using in any
+shared environment.
+
+## API Types
+
+Regenerate TypeScript types from the OpenAPI specs in `docs/*.yaml` (writes to
+both `backend/src/swagger/` and `frontend/src/swagger/`):
+
+```bash
+npm run swagger:gen
+```
+
+Run this after editing any `docs/*.yaml` spec.
+
+## Roles & Access Control
+
+Users have a `role` of `customer` (default) or `owner`. Product reads are public;
+creating, updating, and deleting products requires an authenticated **owner**
+(`authenticate` + `authorize('owner')` on the route).
+
+An account becomes an owner in one of two ways:
+
+- **Seeded owner** — created by `npm run seed` (see above).
+- **`OWNER_EMAILS` allowlist** — a comma-separated list of emails promoted to
+  `owner` on register/login. The allowlist only ever promotes; it never demotes,
+  so the seeded owner keeps its role even if its email isn't listed.
+
+## Environment Variables
+
+See `.env.example` for the full list. Key variables:
+
+| Variable | Purpose |
+|----------|---------|
+| `PORT` | Server port (default `5001`) |
+| `DB_URI` | MongoDB connection string |
+| `ALLOWED_ORIGINS` | Comma-separated CORS origins (required in production) |
+| `JWT_SECRET` / `JWT_REFRESH_SECRET` | Access / refresh token signing secrets |
+| `JWT_EXPIRATION` / `JWT_REFRESH_EXPIRATION` | Token lifetimes (default `15m` / `7d`) |
+| `DEMO_MODE` | `true` runs the app in session-scoped demo mode |
+| `OWNER_EMAILS` | Comma-separated emails granted the `owner` role |
+| `SEED_OWNER_EMAIL` / `SEED_OWNER_PASSWORD` / `SEED_OWNER_NAME` | Demo owner seeded by `npm run seed` |
+
+## Architecture
+
+Requests flow **Route → Controller → Service → Model**:
+
+```
+src/
+├── routes/        # Express route definitions
+├── controllers/   # Request handling, validation, response shaping
+├── services/      # Business logic, database queries, error reporting
+├── models/        # Mongoose schemas + constants
+├── middleware/    # authenticate, authorize, sanitize, error handler, health
+├── docs/          # OpenAPI YAML specs (source of truth for types)
+├── swagger/       # Generated types from OpenAPI
+└── scripts/       # seed.ts and other operational scripts
+```
+
+Errors are constructed via the helpers in `services/error.service.ts`
+(`badRequest`, `unauthorized`, `forbidden`, `notFound`, `conflict`, …) and
+surfaced through `middleware/errorHandler.ts`, which hands each error to
+`reportError()` — the reporting boundary a dedicated error-processing
+microservice is intended to take over.

--- a/backend/README.md
+++ b/backend/README.md
@@ -85,7 +85,9 @@ An account becomes an owner in one of two ways:
 - **Seeded owner** — created by `npm run seed` (see above).
 - **`OWNER_EMAILS` allowlist** — a comma-separated list of emails promoted to
   `owner` on register/login. The allowlist only ever promotes; it never demotes,
-  so the seeded owner keeps its role even if its email isn't listed.
+  so the seeded owner keeps its role even if its email isn't listed. Because the
+  role is carried in the access token, an already-logged-in user must log in
+  again for a newly-added allowlist entry to take effect.
 
 ## Environment Variables
 

--- a/backend/docs/product.yaml
+++ b/backend/docs/product.yaml
@@ -13,6 +13,7 @@ paths:
                   $ref: '#/components/schemas/Product'
     post:
       summary: Create a new product
+      description: Requires an authenticated user with the `owner` role.
       security:
         - bearerAuth: []
       requestBody:
@@ -28,6 +29,10 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Product'
+        '401':
+          description: Missing or invalid authentication token
+        '403':
+          description: Authenticated user is not an owner
   /api/v1/products/{id}:
     get:
       summary: Retrieve a specific product by ID
@@ -48,6 +53,7 @@ paths:
           description: Product not found
     put:
       summary: Update an existing product
+      description: Requires an authenticated user with the `owner` role.
       security:
         - bearerAuth: []
       parameters:
@@ -69,10 +75,15 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Product'
+        '401':
+          description: Missing or invalid authentication token
+        '403':
+          description: Authenticated user is not an owner
         '404':
           description: Product not found
     delete:
       summary: Delete an product by ID
+      description: Requires an authenticated user with the `owner` role.
       security:
         - bearerAuth: []
       parameters:
@@ -84,8 +95,12 @@ paths:
       responses:
         '204':
           description: Product deleted successfully
+        '401':
+          description: Missing or invalid authentication token
+        '403':
+          description: Authenticated user is not an owner
         '404':
-          description: Product not found          
+          description: Product not found
 components:
   schemas:
     Product:

--- a/backend/src/controllers/auth.controller.ts
+++ b/backend/src/controllers/auth.controller.ts
@@ -1,5 +1,6 @@
 import { RequestHandler } from 'express';
 import * as AuthService from '../services/auth.service';
+import { badRequest, unauthorized, notFound } from '../services/error.service';
 import { User } from '../models/user.model';
 
 const REFRESH_COOKIE = 'refresh_token';
@@ -11,16 +12,12 @@ const cookieOptions = {
   maxAge: 7 * 24 * 60 * 60 * 1000,
 };
 
-function badRequestError(message: string): Error {
-  return Object.assign(new Error(message), { statusCode: 400 });
-}
-
 export const register: RequestHandler = async (req, res, next) => {
   try {
     const { email, password, name } = req.body;
-    if (!email) return next(badRequestError('Email is required'));
-    if (!password || password.length < 8) return next(badRequestError('Password must be at least 8 characters'));
-    if (!name) return next(badRequestError('Name is required'));
+    if (!email) return next(badRequest('Email is required'));
+    if (!password || password.length < 8) return next(badRequest('Password must be at least 8 characters'));
+    if (!name) return next(badRequest('Name is required'));
 
     const { authResponse, refreshToken } = await AuthService.register({ email, password, name });
     res.cookie(REFRESH_COOKIE, refreshToken, cookieOptions);
@@ -33,7 +30,7 @@ export const register: RequestHandler = async (req, res, next) => {
 export const login: RequestHandler = async (req, res, next) => {
   try {
     const { email, password } = req.body;
-    if (!email || !password) return next(badRequestError('Email and password are required'));
+    if (!email || !password) return next(badRequest('Email and password are required'));
 
     const { authResponse, refreshToken } = await AuthService.login({ email, password });
     res.cookie(REFRESH_COOKIE, refreshToken, cookieOptions);
@@ -46,7 +43,7 @@ export const login: RequestHandler = async (req, res, next) => {
 export const refresh: RequestHandler = async (req, res, next) => {
   try {
     const token = req.cookies?.[REFRESH_COOKIE];
-    if (!token) return next(Object.assign(new Error('No refresh token'), { statusCode: 401 }));
+    if (!token) return next(unauthorized('No refresh token'));
 
     const result = await AuthService.refreshAccessToken(token);
     res.status(200).json(result);
@@ -73,7 +70,7 @@ export const me: RequestHandler = async (req, res, next) => {
   try {
     const userId = (req as any).user?.userId;
     const user = await User.findById(userId);
-    if (!user) return next(Object.assign(new Error('User not found'), { statusCode: 404 }));
+    if (!user) return next(notFound('User not found'));
     res.status(200).json(AuthService.toSafeUser(user));
   } catch (error) {
     next(error);

--- a/backend/src/controllers/product.controller.ts
+++ b/backend/src/controllers/product.controller.ts
@@ -1,10 +1,7 @@
 import { NextFunction, Request, RequestHandler, Response } from "express";
 import * as ProductService from "../services/product.service";
+import { notFound } from "../services/error.service";
 import { ProductType } from "../types/product.type";
-
-function notFoundError(message: string) {
-  return Object.assign(new Error(message), { statusCode: 404 });
-}
 
 export const getAllProducts: RequestHandler<{}, ProductType[]> = async (
   _req: Request,
@@ -40,7 +37,7 @@ export const getProductById: RequestHandler<{ id: string }, ProductType | null> 
   try {
     const product = await ProductService.findById(req.params.id);
     if (!product) {
-      next?.(notFoundError("Product not found"));
+      next?.(notFound("Product not found"));
       return;
     }
     res.status(200).json(product);
@@ -57,7 +54,7 @@ export const updateProductById: RequestHandler<{ id: string }, ProductType | nul
   try {
     const updatedProduct = await ProductService.updateById(req.params.id, req.body);
     if (!updatedProduct) {
-      next?.(notFoundError("Product not found"));
+      next?.(notFound("Product not found"));
       return;
     }
     res.status(200).json(updatedProduct);
@@ -74,7 +71,7 @@ export const deleteProductById: RequestHandler<{ id: string }, void> = async (
   try {
     const deletedProduct = await ProductService.deleteById(req.params.id);
     if (!deletedProduct) {
-      next?.(notFoundError("Product not found"));
+      next?.(notFound("Product not found"));
       return;
     }
     res.status(204).send();

--- a/backend/src/middleware/authenticate.ts
+++ b/backend/src/middleware/authenticate.ts
@@ -1,11 +1,12 @@
 import { RequestHandler } from 'express';
 import jwt from 'jsonwebtoken';
 import { JWT_SECRET } from '../models/constants';
+import { unauthorized } from '../services/error.service';
 
 export const authenticate: RequestHandler = (req, res, next) => {
   const authHeader = req.headers.authorization;
   if (!authHeader?.startsWith('Bearer ')) {
-    return next(Object.assign(new Error('No token provided'), { statusCode: 401 }));
+    return next(unauthorized('No token provided'));
   }
 
   const token = authHeader.slice(7);
@@ -14,6 +15,6 @@ export const authenticate: RequestHandler = (req, res, next) => {
     (req as any).user = payload;
     next();
   } catch {
-    next(Object.assign(new Error('Invalid or expired token'), { statusCode: 401 }));
+    next(unauthorized('Invalid or expired token'));
   }
 };

--- a/backend/src/middleware/authorize.ts
+++ b/backend/src/middleware/authorize.ts
@@ -1,0 +1,17 @@
+import { RequestHandler } from 'express';
+import { forbidden } from '../services/error.service';
+
+/**
+ * Role-based access control. Runs *after* `authenticate`, which sets
+ * `req.user = { userId, role }`. Rejects with 403 unless the authenticated
+ * user's role is one of the allowed roles.
+ */
+export const authorize = (...roles: string[]): RequestHandler => {
+  return (req, _res, next) => {
+    const user = (req as any).user as { role?: string } | undefined;
+    if (!user?.role || !roles.includes(user.role)) {
+      return next(forbidden('Insufficient permissions'));
+    }
+    next();
+  };
+};

--- a/backend/src/middleware/errorHandler.ts
+++ b/backend/src/middleware/errorHandler.ts
@@ -1,8 +1,9 @@
 import { Request, Response, NextFunction } from "express";
+import { reportError } from "../services/error.service";
 
 export function errorHandler(
     error: any,
-    _req: Request,
+    req: Request,
     res: Response,
     _next: NextFunction
 ) {
@@ -10,7 +11,10 @@ export function errorHandler(
     const message = error.message || "Internal Server Error";
     // Show stack traces in non-production environments for easier debugging
     const stack = process.env.NODE_ENV === "production" ? null : error.stack;
-    if (process.env.NODE_ENV !== 'test'){console.error("ERROR OCCURRED :: ", error)};
+
+    // Hand the error off to the reporting boundary (local sink today; a
+    // dedicated error-processing microservice later).
+    reportError(error, { path: req.path, method: req.method });
 
     res.status(statusCode).json({
         status: statusCode === 500 ? "error" : "fail",

--- a/backend/src/models/constants.ts
+++ b/backend/src/models/constants.ts
@@ -28,3 +28,10 @@ export const SESSION_TIMEOUT = 3600; // Session timeout in seconds (1 hour)
 export const CACHE_TTL = 300; // Cache time-to-live in seconds (5 minutes)
 export const DEMO_MODE = process.env.DEMO_MODE === 'true';
 
+// Comma-separated list of emails that should be granted the `owner` role.
+// Applied on register/login so ownership can be configured without touching the DB.
+export const OWNER_EMAILS = (process.env.OWNER_EMAILS || '')
+    .split(',')
+    .map(email => email.trim().toLowerCase())
+    .filter(Boolean);
+

--- a/backend/src/models/user.model.ts
+++ b/backend/src/models/user.model.ts
@@ -6,7 +6,9 @@ export interface IUser extends Document, Omit<UserType, '_id'> {
   password: string;
 }
 
-interface UserModel extends Model<IUser> {}
+interface UserModel extends Model<IUser> {
+  seed(): Promise<void>;
+}
 
 const userSchema = new Schema<IUser>(
   {
@@ -52,5 +54,25 @@ userSchema.pre(['findOneAndUpdate', 'updateOne'], async function (next) {
 
   next();
 });
+
+// Seed a demo owner account so a fresh database has a user who can manage
+// products. Credentials come from SEED_OWNER_* env vars (with dev defaults).
+// Read lazily from process.env (not module-level constants) so the seed script
+// picks up values loaded via dotenv after import time.
+userSchema.statics.seed = async function () {
+  const email = (process.env.SEED_OWNER_EMAIL || 'owner@spoker.dev').toLowerCase();
+  const password = process.env.SEED_OWNER_PASSWORD || 'ownerpassword';
+  const name = process.env.SEED_OWNER_NAME || 'Demo Owner';
+
+  const existing = await this.findOne({ email });
+  if (existing) {
+    console.log(`⏭️  Skipping owner seed — ${email} already exists.`);
+    return;
+  }
+
+  // Use create() (not insertMany) so the bcrypt pre-save hook hashes the password.
+  await this.create({ email, password, name, role: 'owner' });
+  console.log(`✅ Seeded owner account: ${email}`);
+};
 
 export const User = mongoose.model<IUser, UserModel>('User', userSchema);

--- a/backend/src/routes/product.route.ts
+++ b/backend/src/routes/product.route.ts
@@ -1,17 +1,18 @@
 import express from "express";
 import { getAllProducts, createProduct, getProductById, updateProductById, deleteProductById } from "../controllers/product.controller";
 import { authenticate } from "../middleware/authenticate";
+import { authorize } from "../middleware/authorize";
 import { ProductType } from '../../src/types/product.type';
 
 
 // Define the router
 const router = express.Router();
 
-// Define the routes
+// Define the routes — reads are public; mutations require an authenticated owner
 router.get<{}, ProductType[]>('/', getAllProducts);
 router.get<{ id: string }, ProductType | null>('/:id', getProductById);
-router.post<{}, ProductType>('/', authenticate, createProduct);
-router.put<{ id: string }, ProductType | null>('/:id', authenticate, updateProductById);
-router.delete<{ id: string }, void>('/:id', authenticate, deleteProductById);
+router.post<{}, ProductType>('/', authenticate, authorize('owner'), createProduct);
+router.put<{ id: string }, ProductType | null>('/:id', authenticate, authorize('owner'), updateProductById);
+router.delete<{ id: string }, void>('/:id', authenticate, authorize('owner'), deleteProductById);
 
 export default router;

--- a/backend/src/scripts/seed.ts
+++ b/backend/src/scripts/seed.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import dotenv from 'dotenv';
 import mongoose from 'mongoose';
 import { Product } from '../models/product.model';
+import { User } from '../models/user.model';
 
 // Parse args
 const args = process.argv.slice(2);
@@ -29,6 +30,7 @@ async function main() {
     }
 
     await Product.seed();
+    await User.seed();
 
     await mongoose.connection.close();
     console.log('🔌 Disconnected');

--- a/backend/src/services/auth.service.ts
+++ b/backend/src/services/auth.service.ts
@@ -3,13 +3,32 @@ import jwt from 'jsonwebtoken';
 import { User, IUser } from '../models/user.model';
 import { RefreshToken } from '../models/refresh-token.model';
 import { RegisterRequest, LoginRequest, AuthResponse, UserType } from '../types/user.type';
-import { JWT_SECRET, JWT_EXPIRATION, JWT_REFRESH_SECRET, JWT_REFRESH_EXPIRATION } from '../models/constants';
+import { JWT_SECRET, JWT_EXPIRATION, JWT_REFRESH_SECRET, JWT_REFRESH_EXPIRATION, OWNER_EMAILS } from '../models/constants';
+import { conflict, unauthorized } from './error.service';
 
 // Dummy hash used for timing-safe rejection when user is not found
 const DUMMY_HASH = '$2b$12$invalidhashfortimingprotectiononly000000000000000000000';
 
-function makeError(message: string, statusCode: number): Error {
-  return Object.assign(new Error(message), { statusCode });
+type Role = UserType['role'];
+
+/**
+ * Resolve the effective role for an email against the OWNER_EMAILS allowlist.
+ * The allowlist only ever *promotes* to `owner` — it never demotes, so a
+ * seeded owner (not necessarily in the allowlist) keeps its role.
+ */
+export function resolveRole(email: string, currentRole: Role = 'customer'): Role {
+  if (OWNER_EMAILS.includes(email.toLowerCase())) return 'owner';
+  return currentRole;
+}
+
+/** Reconcile a user's stored role with the allowlist, persisting any promotion. */
+async function reconcileRole(user: IUser): Promise<Role> {
+  const effectiveRole = resolveRole(user.email, user.role);
+  if (effectiveRole !== user.role) {
+    user.role = effectiveRole;
+    await user.save();
+  }
+  return effectiveRole;
 }
 
 export function toSafeUser(user: IUser): UserType {
@@ -37,10 +56,15 @@ async function storeRefreshToken(token: string, userId: string): Promise<void> {
 export async function register(data: RegisterRequest): Promise<{ authResponse: AuthResponse; refreshToken: string }> {
   const existing = await User.findOne({ email: data.email.toLowerCase() });
   if (existing) {
-    throw makeError('Email already in use', 409);
+    throw conflict('Email already in use');
   }
 
-  const user = new User({ email: data.email, password: data.password, name: data.name });
+  const user = new User({
+    email: data.email,
+    password: data.password,
+    name: data.name,
+    role: resolveRole(data.email),
+  });
   await user.save();
 
   const { accessToken, refreshToken } = generateTokens((user._id as any).toString(), user.role);
@@ -57,10 +81,11 @@ export async function login(data: LoginRequest): Promise<{ authResponse: AuthRes
   // Always run bcrypt.compare to prevent timing attacks that reveal valid emails
   const passwordMatch = await bcrypt.compare(data.password, user?.password ?? DUMMY_HASH);
   if (!user || !passwordMatch) {
-    throw makeError('Invalid credentials', 401);
+    throw unauthorized('Invalid credentials');
   }
 
-  const { accessToken, refreshToken } = generateTokens((user._id as any).toString(), user.role);
+  const role = await reconcileRole(user);
+  const { accessToken, refreshToken } = generateTokens((user._id as any).toString(), role);
   await storeRefreshToken(refreshToken, (user._id as any).toString());
   return {
     authResponse: { accessToken, user: toSafeUser(user) },
@@ -73,20 +98,21 @@ export async function refreshAccessToken(refreshToken: string): Promise<AuthResp
   try {
     payload = jwt.verify(refreshToken, JWT_REFRESH_SECRET) as { userId: string };
   } catch {
-    throw makeError('Invalid or expired refresh token', 401);
+    throw unauthorized('Invalid or expired refresh token');
   }
 
   const stored = await RefreshToken.findOne({ token: refreshToken });
   if (!stored) {
-    throw makeError('Refresh token not recognized', 401);
+    throw unauthorized('Refresh token not recognized');
   }
 
   const user = await User.findById(payload.userId);
   if (!user) {
-    throw makeError('User not found', 401);
+    throw unauthorized('User not found');
   }
 
-  const accessToken = jwt.sign({ userId: payload.userId, role: user.role }, JWT_SECRET, { expiresIn: JWT_EXPIRATION } as jwt.SignOptions);
+  const role = await reconcileRole(user);
+  const accessToken = jwt.sign({ userId: payload.userId, role }, JWT_SECRET, { expiresIn: JWT_EXPIRATION } as jwt.SignOptions);
   return { accessToken, user: toSafeUser(user) };
 }
 

--- a/backend/src/services/error.service.ts
+++ b/backend/src/services/error.service.ts
@@ -1,0 +1,92 @@
+/**
+ * Error service — the single home for application error construction and
+ * error reporting.
+ *
+ * Two responsibilities:
+ *  1. A typed error factory (`createError` + named helpers) so controllers,
+ *     services, and middleware stop hand-rolling `Object.assign(new Error(), …)`.
+ *  2. `reportError()` — a structured reporting boundary. Today it logs locally,
+ *     but it is the single seam a dedicated error-processing microservice
+ *     (planned in C++) will take over. Keep the `ErrorEvent` shape stable:
+ *     it is the wire contract that service will consume.
+ */
+
+/** An Error carrying an HTTP status code. The `{ statusCode }` contract is what
+ *  `middleware/errorHandler.ts` reads to build the response. */
+export interface AppError extends Error {
+  statusCode: number;
+}
+
+/** Structured, transport-ready representation of an error. This is the wire
+ *  contract for the future error-processing microservice — additive changes
+ *  only. */
+export interface ErrorEvent {
+  message: string;
+  statusCode: number;
+  name: string;
+  stack?: string;
+  path?: string;
+  method?: string;
+  timestamp: string;
+  service: string;
+}
+
+const SERVICE_NAME = 'spoker-backend';
+
+/** Create an Error tagged with an HTTP status code. */
+export function createError(message: string, statusCode: number): AppError {
+  return Object.assign(new Error(message), { statusCode });
+}
+
+export const badRequest = (message = 'Bad Request'): AppError => createError(message, 400);
+export const unauthorized = (message = 'Unauthorized'): AppError => createError(message, 401);
+export const forbidden = (message = 'Forbidden'): AppError => createError(message, 403);
+export const notFound = (message = 'Not Found'): AppError => createError(message, 404);
+export const conflict = (message = 'Conflict'): AppError => createError(message, 409);
+export const internal = (message = 'Internal Server Error'): AppError => createError(message, 500);
+
+/** Minimal shape of a request we care about for reporting — avoids coupling the
+ *  service to Express's full `Request` type. */
+interface RequestContext {
+  path?: string;
+  method?: string;
+}
+
+/** Normalize any thrown value into a structured `ErrorEvent`. */
+export function toErrorEvent(error: any, context?: RequestContext): ErrorEvent {
+  const statusCode = typeof error?.statusCode === 'number' ? error.statusCode : 500;
+  return {
+    message: error?.message ?? 'Internal Server Error',
+    statusCode,
+    name: error?.name ?? 'Error',
+    stack: error?.stack,
+    path: context?.path,
+    method: context?.method,
+    timestamp: new Date().toISOString(),
+    service: SERVICE_NAME,
+  };
+}
+
+/**
+ * Dispatch an error event to its sink.
+ *
+ * TODO(microservices): swap this local console sink for a dispatch to the C++
+ * error-processing service (e.g. an HTTP/gRPC POST of the `ErrorEvent`). The
+ * `ErrorEvent` shape above is the wire contract — keep it stable.
+ */
+function dispatch(event: ErrorEvent): void {
+  // Suppressed under test to keep suite output clean (matches prior behavior).
+  if (process.env.NODE_ENV === 'test') return;
+  console.error('ERROR OCCURRED :: ', event);
+}
+
+/**
+ * Report an error. Normalizes it into an `ErrorEvent`, dispatches it to the
+ * sink, and returns the event (useful for callers/tests). This is the boundary
+ * a remote error-processing microservice will eventually own.
+ */
+export function reportError(error: any, context?: RequestContext): ErrorEvent {
+  const event = toErrorEvent(error, context);
+  dispatch(event);
+  return event;
+}

--- a/backend/tests/api/product.spec.ts
+++ b/backend/tests/api/product.spec.ts
@@ -5,6 +5,7 @@ import * as ProductService from '../../src/services/product.service';
 import app from '../../src/app';
 import request from 'supertest';
 import { jest } from "@jest/globals";
+import jwt from 'jsonwebtoken';
 import { ProductType } from '../../src/types/product.type';
 import { API_URL, Routes } from '../../src/models/constants';
 
@@ -165,5 +166,34 @@ describe('Product API', () => {
     jest.spyOn(ProductService, 'findAll').mockResolvedValue([] as any);
     const res = await request(app).get(API_URL + Routes.PRODUCTS + 'badroute');
     expect(res.status).toBe(404);
+  });
+})
+
+describe('Product API — RBAC on mutations', () => {
+  const sign = (role: string) =>
+    jwt.sign({ userId: 'u1', role }, process.env.JWT_SECRET as string);
+
+  const newProduct = { name: 'X', description: 'Y', msrp: 10, price: 9 };
+
+  it('rejects POST with no token (401)', async () => {
+    const res = await request(app).post(API_URL + Routes.PRODUCTS).send(newProduct);
+    expect(res.status).toBe(401);
+  });
+
+  it('rejects POST from a customer (403)', async () => {
+    const res = await request(app)
+      .post(API_URL + Routes.PRODUCTS)
+      .set('Authorization', `Bearer ${sign('customer')}`)
+      .send(newProduct);
+    expect(res.status).toBe(403);
+  });
+
+  it('allows POST from an owner (passes authorization)', async () => {
+    jest.spyOn(ProductService, 'create').mockResolvedValue({ _id: '1', ...newProduct } as any);
+    const res = await request(app)
+      .post(API_URL + Routes.PRODUCTS)
+      .set('Authorization', `Bearer ${sign('owner')}`)
+      .send(newProduct);
+    expect(res.status).toBe(201);
   });
 })

--- a/backend/tests/middleware/authorize.spec.ts
+++ b/backend/tests/middleware/authorize.spec.ts
@@ -1,0 +1,44 @@
+import { jest } from '@jest/globals';
+import { authorize } from '../../src/middleware/authorize';
+
+describe('authorize middleware', () => {
+  it('calls next with no args when the user has an allowed role', () => {
+    const req: any = { user: { userId: 'u1', role: 'owner' } };
+    const res: any = {};
+    const next = jest.fn();
+
+    authorize('owner')(req, res, next);
+
+    expect(next).toHaveBeenCalledWith();
+  });
+
+  it('calls next with 403 when the user role is not allowed', () => {
+    const req: any = { user: { userId: 'u1', role: 'customer' } };
+    const res: any = {};
+    const next = jest.fn();
+
+    authorize('owner')(req, res, next);
+
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
+  });
+
+  it('calls next with 403 when req.user is missing', () => {
+    const req: any = {};
+    const res: any = {};
+    const next = jest.fn();
+
+    authorize('owner')(req, res, next);
+
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 403 }));
+  });
+
+  it('accepts any of several allowed roles', () => {
+    const req: any = { user: { userId: 'u1', role: 'customer' } };
+    const res: any = {};
+    const next = jest.fn();
+
+    authorize('owner', 'customer')(req, res, next);
+
+    expect(next).toHaveBeenCalledWith();
+  });
+});

--- a/backend/tests/services/auth.service.spec.ts
+++ b/backend/tests/services/auth.service.spec.ts
@@ -139,4 +139,20 @@ describe('AuthService', () => {
       expect(tokens).toHaveProperty('refreshToken');
     });
   });
+
+  describe('resolveRole', () => {
+    // OWNER_EMAILS is empty in the test environment, so these cover the
+    // no-promotion paths — including the safety property that it never demotes.
+    it('defaults to customer when no current role is given', () => {
+      expect(AuthService.resolveRole('someone@test.com')).toBe('customer');
+    });
+
+    it('keeps a customer as customer when not on the allowlist', () => {
+      expect(AuthService.resolveRole('someone@test.com', 'customer')).toBe('customer');
+    });
+
+    it('never demotes an existing owner not on the allowlist', () => {
+      expect(AuthService.resolveRole('owner@spoker.dev', 'owner')).toBe('owner');
+    });
+  });
 });

--- a/backend/tests/services/error.service.spec.ts
+++ b/backend/tests/services/error.service.spec.ts
@@ -1,0 +1,70 @@
+import {
+  createError,
+  badRequest,
+  unauthorized,
+  forbidden,
+  notFound,
+  conflict,
+  internal,
+  toErrorEvent,
+  reportError,
+} from '../../src/services/error.service';
+
+describe('error.service factory helpers', () => {
+  it('createError attaches the given status code and message', () => {
+    const err = createError('boom', 418);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.message).toBe('boom');
+    expect(err.statusCode).toBe(418);
+  });
+
+  it('named helpers carry the right status codes', () => {
+    expect(badRequest().statusCode).toBe(400);
+    expect(unauthorized().statusCode).toBe(401);
+    expect(forbidden().statusCode).toBe(403);
+    expect(notFound().statusCode).toBe(404);
+    expect(conflict().statusCode).toBe(409);
+    expect(internal().statusCode).toBe(500);
+  });
+
+  it('named helpers accept a custom message', () => {
+    expect(notFound('Product not found').message).toBe('Product not found');
+  });
+});
+
+describe('error.service reporting', () => {
+  it('toErrorEvent normalizes an AppError into the wire contract', () => {
+    const event = toErrorEvent(notFound('missing'), { path: '/api/v1/products/1', method: 'GET' });
+    expect(event).toEqual(
+      expect.objectContaining({
+        message: 'missing',
+        statusCode: 404,
+        name: 'Error',
+        path: '/api/v1/products/1',
+        method: 'GET',
+        service: 'spoker-backend',
+      })
+    );
+    expect(typeof event.timestamp).toBe('string');
+  });
+
+  it('toErrorEvent defaults to 500 for an untagged error', () => {
+    const event = toErrorEvent(new Error('plain'));
+    expect(event.statusCode).toBe(500);
+    expect(event.message).toBe('plain');
+  });
+
+  it('toErrorEvent tolerates non-Error throwables', () => {
+    const event = toErrorEvent('just a string');
+    expect(event.statusCode).toBe(500);
+    expect(event.message).toBe('Internal Server Error');
+    expect(event.name).toBe('Error');
+  });
+
+  it('reportError returns the normalized event', () => {
+    const event = reportError(forbidden('nope'), { path: '/x', method: 'POST' });
+    expect(event.statusCode).toBe(403);
+    expect(event.message).toBe('nope');
+    expect(event.service).toBe('spoker-backend');
+  });
+});

--- a/frontend/src/app/components/dashboard/products/products.component.html
+++ b/frontend/src/app/components/dashboard/products/products.component.html
@@ -1,7 +1,9 @@
 <div class="products-container">
   <div class="header">
     <h1>Products</h1>
-    <button class="btn-primary" type="button" (click)="openCreateForm()">Add Product</button>
+    @if (canManageProducts()) {
+      <button class="btn-primary" type="button" (click)="openCreateForm()">Add Product</button>
+    }
   </div>
 
   @if (productService.loading()) {
@@ -21,7 +23,9 @@
     @if (productService.products().length === 0) {
       <div class="empty-state">
         <p>No products found</p>
-        <button class="btn-primary" type="button" (click)="openCreateForm()">Add Your First Product</button>
+        @if (canManageProducts()) {
+          <button class="btn-primary" type="button" (click)="openCreateForm()">Add Your First Product</button>
+        }
       </div>
     } @else {
       <div class="products-grid">
@@ -29,10 +33,12 @@
           <div class="product-card">
             <div class="product-header">
               <h3>{{ product.name }}</h3>
-              <div class="product-actions">
-                <button class="btn-icon" type="button" title="Edit" aria-label="Edit product" (click)="openEditForm(product)">✏️</button>
-                <button class="btn-icon" type="button" title="Delete" aria-label="Delete product" (click)="openDeleteConfirm(product._id, product.name)">🗑️</button>
-              </div>
+              @if (canManageProducts()) {
+                <div class="product-actions">
+                  <button class="btn-icon" type="button" title="Edit" aria-label="Edit product" (click)="openEditForm(product)">✏️</button>
+                  <button class="btn-icon" type="button" title="Delete" aria-label="Delete product" (click)="openDeleteConfirm(product._id, product.name)">🗑️</button>
+                </div>
+              }
             </div>
 
             <p class="product-description">{{ product.description }}</p>

--- a/frontend/src/app/components/dashboard/products/products.component.spec.ts
+++ b/frontend/src/app/components/dashboard/products/products.component.spec.ts
@@ -3,6 +3,9 @@ import { signal } from '@angular/core';
 
 import { ProductsComponent } from './products.component';
 import { ProductService } from '../../../services/product/product.service';
+import { AuthService } from '../../../services/auth/auth.service';
+import { ConfigService } from '../../../services/config.service';
+import { DemoService } from '../../../services/demo/demo.service';
 
 describe('ProductsComponent', () => {
   let component: ProductsComponent;
@@ -16,6 +19,9 @@ describe('ProductsComponent', () => {
     loading: ReturnType<typeof signal>;
     error: ReturnType<typeof signal>;
   };
+  let authService: { currentUser: ReturnType<typeof signal> };
+  let configService: { demoMode: ReturnType<typeof signal> };
+  let demoService: { demoRole: ReturnType<typeof signal> };
 
   const mockProducts = [
     { _id: '1', name: 'Widget', description: 'A test widget', msrp: 100, price: 90 },
@@ -33,13 +39,18 @@ describe('ProductsComponent', () => {
       error: signal(null)
     };
 
+    // Default to an owner (real, non-demo mode) so product-management controls render.
+    authService = { currentUser: signal({ _id: 'u1', email: 'owner@test.com', name: 'Owner', role: 'owner' }) };
+    configService = { demoMode: signal(false) };
+    demoService = { demoRole: signal('owner') };
+
     await TestBed.configureTestingModule({
       imports: [ProductsComponent],
       providers: [
-        {
-          provide: ProductService,
-          useValue: productService
-        }
+        { provide: ProductService, useValue: productService },
+        { provide: AuthService, useValue: authService },
+        { provide: ConfigService, useValue: configService },
+        { provide: DemoService, useValue: demoService }
       ]
     })
     .compileComponents();
@@ -464,6 +475,54 @@ describe('ProductsComponent', () => {
 
       expect(msrpValues[0]?.textContent).toContain('$100.00');
       expect(priceValues[0]?.textContent).toContain('$90.00');
+    });
+  });
+
+  describe('Role-based UI gating', () => {
+    it('canManageProducts is true for an owner in real mode', () => {
+      expect(component.canManageProducts()).toBeTrue();
+    });
+
+    it('canManageProducts is false for a customer in real mode', () => {
+      authService.currentUser.set({ _id: 'u2', email: 'c@test.com', name: 'Cust', role: 'customer' });
+      expect(component.canManageProducts()).toBeFalse();
+    });
+
+    it('canManageProducts follows demoRole in demo mode', () => {
+      configService.demoMode.set(true);
+      demoService.demoRole.set('owner');
+      expect(component.canManageProducts()).toBeTrue();
+
+      demoService.demoRole.set('customer');
+      expect(component.canManageProducts()).toBeFalse();
+    });
+
+    it('hides the Add Product button for a customer', () => {
+      authService.currentUser.set({ _id: 'u2', email: 'c@test.com', name: 'Cust', role: 'customer' });
+      fixture.detectChanges();
+
+      const addButton = fixture.nativeElement.querySelector('.header button');
+
+      expect(addButton).toBeFalsy();
+    });
+
+    it('hides product action buttons for a customer', () => {
+      authService.currentUser.set({ _id: 'u2', email: 'c@test.com', name: 'Cust', role: 'customer' });
+      productService.products.set(mockProducts);
+      fixture.detectChanges();
+
+      const actions = fixture.nativeElement.querySelectorAll('.product-actions');
+
+      expect(actions.length).toBe(0);
+    });
+
+    it('shows product action buttons for an owner', () => {
+      productService.products.set(mockProducts);
+      fixture.detectChanges();
+
+      const actions = fixture.nativeElement.querySelectorAll('.product-actions');
+
+      expect(actions.length).toBe(2);
     });
   });
 

--- a/frontend/src/app/components/dashboard/products/products.component.spec.ts
+++ b/frontend/src/app/components/dashboard/products/products.component.spec.ts
@@ -524,6 +524,25 @@ describe('ProductsComponent', () => {
 
       expect(actions.length).toBe(2);
     });
+
+    it('hides the empty-state Add button for a customer', () => {
+      authService.currentUser.set({ _id: 'u2', email: 'c@test.com', name: 'Cust', role: 'customer' });
+      productService.products.set([]);
+      fixture.detectChanges();
+
+      const emptyStateButton = fixture.nativeElement.querySelector('.empty-state button');
+
+      expect(emptyStateButton).toBeFalsy();
+    });
+
+    it('shows the empty-state Add button for an owner', () => {
+      productService.products.set([]);
+      fixture.detectChanges();
+
+      const emptyStateButton = fixture.nativeElement.querySelector('.empty-state button');
+
+      expect(emptyStateButton).toBeTruthy();
+    });
   });
 
   describe('Component accessibility', () => {

--- a/frontend/src/app/components/dashboard/products/products.component.ts
+++ b/frontend/src/app/components/dashboard/products/products.component.ts
@@ -1,6 +1,9 @@
-import { Component, OnInit, inject } from '@angular/core';
+import { Component, OnInit, computed, inject } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ProductService } from '../../../services/product/product.service';
+import { AuthService } from '../../../services/auth/auth.service';
+import { ConfigService } from '../../../services/config.service';
+import { DemoService } from '../../../services/demo/demo.service';
 import { ProductFormComponent, ProductFormData } from './product-form/product-form.component';
 import type { ProductComponents } from '../../../../swagger';
 
@@ -15,6 +18,17 @@ type Product = ProductComponents['schemas']['Product'];
 })
 export class ProductsComponent implements OnInit {
   productService = inject(ProductService);
+  private auth = inject(AuthService);
+  private config = inject(ConfigService);
+  private demo = inject(DemoService);
+
+  // Only owners can manage products. In demo mode the banner's role toggle
+  // (demoRole) drives this; otherwise it's the authenticated user's role.
+  canManageProducts = computed(() =>
+    this.config.demoMode()
+      ? this.demo.demoRole() === 'owner'
+      : this.auth.currentUser()?.role === 'owner'
+  );
 
   // Delete modal state
   isDeleteModalOpen = false;


### PR DESCRIPTION
Tidy the concrete gaps left after M1 before starting M2.

Error service (backend/src/services/error.service.ts):
- Fill the previously empty file with a typed error factory (createError +
  badRequest/unauthorized/forbidden/notFound/conflict/internal), replacing the
  four inline `Object.assign(new Error(), { statusCode })` copies in
  product.controller, auth.controller, auth.service, and authenticate.
- Add reportError()/ErrorEvent as a structured reporting boundary; errorHandler
  now delegates to it. This is the seam a future error-processing microservice
  will take over (wire contract documented in-file).

RBAC:
- New authorize(...roles) middleware; product create/update/delete now require
  an authenticated owner. Reads stay public.
- Owner path: User.seed() creates a demo owner (SEED_OWNER_* env, sensible
  defaults), wired into the seed script; OWNER_EMAILS allowlist promotes matching
  emails to owner on register/login/refresh (promotes only, never demotes).
- Frontend gates Add/Edit/Delete product controls on role (owner in real mode,
  demoRole in demo mode).
- product.yaml documents the owner requirement + 401/403 responses.

Docs/tests:
- Write backend/README.md (was empty); update .env.example with the new vars.
- Add error.service and authorize specs; add resolveRole and route-level RBAC
  (401/403/201) tests; extend products.component spec for the gated states.